### PR TITLE
Notify action should check for state machine before apply transition

### DIFF
--- a/src/Action/NotifyAction.php
+++ b/src/Action/NotifyAction.php
@@ -56,7 +56,10 @@ final class NotifyAction implements ActionInterface, ApiAwareInterface
 
             Assert::isInstanceOf($payment, PaymentInterface::class);
 
-            $this->stateMachineFactory->get($payment, PaymentTransitions::GRAPH)->apply(PaymentTransitions::TRANSITION_COMPLETE);
+            $sm = $this->stateMachineFactory->get($payment, PaymentTransitions::GRAPH);
+            if ($sm->can(PaymentTransitions::TRANSITION_COMPLETE)) {
+                $sm->apply(PaymentTransitions::TRANSITION_COMPLETE);
+            }
         }
     }
 


### PR DESCRIPTION
Fixed #2 // Notify action should check for state machine before apply transition