### PR TITLE
Update AxeptaGatewayConfigurationType.php

### DIFF
--- a/src/Form/Type/AxeptaGatewayConfigurationType.php
+++ b/src/Form/Type/AxeptaGatewayConfigurationType.php
@@ -60,6 +60,7 @@ final class AxeptaGatewayConfigurationType extends AbstractType
             ->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
                 $data = $event->getData();
                 $data['payum.http_client'] = '@waaz.axepta.bridge.axepta_bridge';
+                $data['payum.factory_name'] = 'axepta';
                 $event->setData($data);
             })
         ;


### PR DESCRIPTION
Starting Sylius 2.0 `getFactoryName()` and `setFactoryName()` will be deprecated set factory option inside the config (see \Payum\Core\Model\GatewayConfigInterface)

As of Sylius 1.3.3 those methods are deprecated and WaazAxeptaPlugin is currently not saving factory name inside the configuration.


**I also suggest you to make a migration that will automatically handle previously saved gateway configs that does not contain the factory name.**